### PR TITLE
fix: Create text-justify css class

### DIFF
--- a/assets/styles/components/texts.scss
+++ b/assets/styles/components/texts.scss
@@ -33,6 +33,9 @@ blockquote {
   }
 }
 
+.text-justify {
+  text-align: justify;
+
 .text-muted {
   color: get-light-color('muted-text-color') !important;
 }


### PR DESCRIPTION
### Description

.text-justify is used on some texts but never defined
